### PR TITLE
Treat 'master' branch as 'trunk' in Jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
                     def name = "hydra-service"
                     def version = env.BUILD_NUMBER
 
-                    if (env.BRANCH_NAME != 'master') {
+                    if (!env.BRANCH_NAME ==~ /master|trunk/ ) {
                         def branchSplit = env.BRANCH_NAME.split('/')
                         def gitBranchName = branchSplit[1]
                         version = gitBranchName + '-' + env.BUILD_NUMBER


### PR DESCRIPTION
For some reason the master git branch is called 'trunk' in Jenkins, so check for 'trunk' in branch name as well.