### PR TITLE
Remove logging of RecordIds

### DIFF
--- a/hydra-api/src/main/java/dk/dbc/hydra/QueueAPI.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/QueueAPI.java
@@ -129,7 +129,6 @@ public class QueueAPI {
                     agencySummary.put(agencyId, count);
                 }
 
-                LOGGER.debug("{} = {}", sessionId, queueJob);
                 this.jobCache.put(sessionId, queueJob);
 
                 agencySummary.forEach((key, value) -> response.getAgencyAnalysisList().add(new AgencyAnalysis(key, value)));

--- a/hydra-api/src/main/java/dk/dbc/hydra/dao/RawRepoConnector.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/dao/RawRepoConnector.java
@@ -251,7 +251,8 @@ public class RawRepoConnector {
 
             return result;
         } finally {
-            LOGGER.exit(result);
+            // Not logging result as it may be millions of RecordIds
+            LOGGER.exit();
         }
     }
 


### PR DESCRIPTION
When validating large sets of RecordIds (e.g. 870970) the printing of all those sets took longer than getting them from the database. Plus during debugging the log line could be so big that it crashed the session.