### PR TITLE
Use the same provider function

### DIFF
--- a/hydra-api/src/main/java/dk/dbc/hydra/QueueAPI.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/QueueAPI.java
@@ -383,7 +383,7 @@ public class QueueAPI {
     @Stopwatch
     @GET
     @Produces({MediaType.APPLICATION_JSON})
-    @Path(ApplicationConstants.API_QUEUE_PROVIDER_NAMES)
+    @Path(ApplicationConstants.API_QUEUE_PROVIDERS)
     public Response getProviderNames() {
         LOGGER.entry();
         String res = "";
@@ -396,32 +396,6 @@ public class QueueAPI {
             return Response.ok(res, MediaType.APPLICATION_JSON).build();
         } catch (SQLException | JSONBException ex) {
             LOGGER.error("Exception during getProviderInfo", ex);
-            return Response.serverError().entity(ex.toString()).build();
-        } finally {
-            LOGGER.exit(res);
-        }
-    }
-
-
-    @Stopwatch
-    @GET
-    @Produces({MediaType.APPLICATION_JSON})
-    @Path(ApplicationConstants.API_QUEUE_PROVIDER_DETAILS)
-    public Response getProviderInfo() {
-        LOGGER.entry();
-        String res = "";
-
-        try {
-            List<QueueProvider> providers = rawrepo.getProviders();
-            LOGGER.info(providers.toString());
-
-            HashMap<String, List<QueueProvider>> resultObject = new HashMap<>();
-            resultObject.putIfAbsent("providers", providers);
-
-            res = jsonbContext.marshall(resultObject);
-            return Response.ok(res, MediaType.APPLICATION_JSON).build();
-        } catch (Exception ex) {
-            LOGGER.error("Unexpected exception:", ex);
             return Response.serverError().entity(ex.toString()).build();
         } finally {
             LOGGER.exit(res);

--- a/hydra-api/src/main/java/dk/dbc/hydra/common/ApplicationConstants.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/common/ApplicationConstants.java
@@ -11,8 +11,7 @@ public class ApplicationConstants {
     public static final String API_QUEUE_VALIDATE = "validate";
     public static final String API_QUEUE_PROCESS = "process";
     public static final String API_QUEUE_TYPES = "types";
-    public static final String API_QUEUE_PROVIDER_NAMES = "providerNames";
-    public static final String API_QUEUE_PROVIDER_DETAILS = "providerDetails";
+    public static final String API_QUEUE_PROVIDERS = "providers";
 
     public static final String API_LIBRARY = "/library";
     public static final String API_LIBRARY_CATALOGING_TEMPLATE_SET = "catalogingTemplateSet";

--- a/hydra-api/src/main/webapp/providers.html
+++ b/hydra-api/src/main/webapp/providers.html
@@ -32,13 +32,13 @@
             }
 
             getProviderInfo() {
-                superagent.get('/api/queue/providerDetails').end((err, res) => {
+                superagent.get('/api/queue/providers').end((err, res) => {
                     if (err) {
-                        alert("FEJL!\n\nDen opstod fejl under kald til /api/stats/queueByWorker:\n" + err)
+                        alert("FEJL!\n\nDen opstod fejl under kald til /api/queue/providers:\n" + err)
                     } else if (res.body === null) {
-                        alert('FEJL!\n\nDer kom tomt svar tilbage fra /api/queue/providerInfo');
+                        alert('FEJL!\n\nDer kom tomt svar tilbage fra /api/queue/providers');
                     } else {
-                        this.setState({providerInfo: res.body.providers});
+                        this.setState({providerInfo: res.body});
                     }
                 });
 

--- a/hydra-gui/app/components/hydra-queue.js
+++ b/hydra-gui/app/components/hydra-queue.js
@@ -226,11 +226,11 @@ class HydraQueue extends React.Component {
     }
 
     getProvidersOptions() {
-        superagent.get('/api/queue/providerNames').end((err, res) => {
+        superagent.get('/api/queue/providers').end((err, res) => {
             if (err) {
-                alert("FEJL!\n\nDen opstod fejl under kald til /api/queue/providerNames:\n" + err)
+                alert("FEJL!\n\nDen opstod fejl under kald til /api/queue/providers:\n" + err)
             } else if (res.body === null) {
-                alert('FEJL!\n\nDer kom tomt svar tilbage fra /api/queue/providerNames');
+                alert('FEJL!\n\nDer kom tomt svar tilbage fra /api/queue/providers');
             } else {
                 let providerNames = [];
 


### PR DESCRIPTION
There were two provider function with slightly different name and
slightly different logic, both they produced the exact same output.
Therefor the uglier of the two function has been removed and all calls
to get providers point to the remaining function.