### PR TITLE
Make records summary even more user friendly

### DIFF
--- a/hydra-api/src/main/java/dk/dbc/hydra/dao/RawRepoConnector.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/dao/RawRepoConnector.java
@@ -27,11 +27,13 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.TimeZone;
 
 @Interceptors(StopwatchInterceptor.class)
 @Stateless
@@ -326,6 +328,8 @@ public class RawRepoConnector {
     public List<RecordSummary> getRecordsSummary() throws SQLException {
         LOGGER.entry();
         List<RecordSummary> result = new ArrayList<>();
+        final SimpleDateFormat danishDateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        danishDateFormat.setTimeZone(TimeZone.getTimeZone("Europe/Copenhagen"));
 
         try (Connection connection = globalDataSource.getConnection();
              Statement stmt = connection.createStatement()) {
@@ -337,7 +341,11 @@ public class RawRepoConnector {
                     final int deletedCount = resultSet.getInt("deleted_count");
                     final Timestamp ajourDate = resultSet.getTimestamp("ajour_date");
 
-                    result.add(new RecordSummary(agencyId, originalCount, enrichmentCount, deletedCount, ajourDate));
+                    result.add(new RecordSummary(agencyId,
+                            originalCount,
+                            enrichmentCount,
+                            deletedCount,
+                            danishDateFormat.format(ajourDate)));
                 }
             }
 

--- a/hydra-api/src/main/java/dk/dbc/hydra/stats/RecordSummary.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/stats/RecordSummary.java
@@ -5,9 +5,6 @@
 
 package dk.dbc.hydra.stats;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
 public class RecordSummary {
 
     private int agencyId;
@@ -16,15 +13,12 @@ public class RecordSummary {
     private int deletedCount;
     private String ajourDate;
 
-    public RecordSummary() {
-    }
-
-    public RecordSummary(int agencyId, int originalCount, int enrichmentCount, int deletedCount, Date ajourDate) {
+    public RecordSummary(int agencyId, int originalCount, int enrichmentCount, int deletedCount, String ajourDate) {
         this.agencyId = agencyId;
         this.originalCount = originalCount;
         this.enrichmentCount = enrichmentCount;
         this.deletedCount = deletedCount;
-        this.ajourDate = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS").format(ajourDate);
+        this.ajourDate = ajourDate;
     }
 
     public int getAgencyId() {
@@ -54,7 +48,7 @@ public class RecordSummary {
                 ", originalCount=" + originalCount +
                 ", enrichmentCount=" + enrichmentCount +
                 ", deletedCount=" + deletedCount +
-                ", ajourDate=" + ajourDate +
+                ", ajourDate='" + ajourDate + '\'' +
                 '}';
     }
 }

--- a/hydra-gui/app/components/hydra-statistics-records.js
+++ b/hydra-gui/app/components/hydra-statistics-records.js
@@ -8,6 +8,11 @@ import {BootstrapTable, TableHeaderColumn} from 'react-bootstrap-table';
 import {Button} from 'react-bootstrap';
 import superagent from 'superagent';
 
+// This function puts '.' as thousand separator in the given cell value
+const integerFormatter = function (cell, row) {
+    return cell.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ".");
+};
+
 class HydraStatisticsRecords extends React.Component {
     constructor(props) {
         super(props);
@@ -48,7 +53,8 @@ class HydraStatisticsRecords extends React.Component {
                     onClick={this.getRecordsSummary}
                     type='submit'
                     className='btn btn-success'
-                    disabled={this.state.loadingRecordsSummary}>
+                    disabled={this.state.loadingRecordsSummary}
+                >
                     Genindlæs
                 </Button>
                 <br/>
@@ -56,12 +62,34 @@ class HydraStatisticsRecords extends React.Component {
                     data={this.state.recordsSummaryData}
                     striped={true}
                     options={{noDataText: 'Der blev ikke fundet nogen rækker'}}
-                    bordered={false}>
-                    <TableHeaderColumn dataField='agencyId' isKey dataSort>Bibliotek</TableHeaderColumn>
-                    <TableHeaderColumn dataField='originalCount' dataSort>Originalposter</TableHeaderColumn>
-                    <TableHeaderColumn dataField='enrichmentCount' dataSort>Påhængsposter</TableHeaderColumn>
-                    <TableHeaderColumn dataField='deletedCount' dataSort>Sletteposter</TableHeaderColumn>
-                    <TableHeaderColumn dataField='ajourDate' dataSort>Ajourdato</TableHeaderColumn>
+                    bordered={false}
+                    condensed={true}>
+                    <TableHeaderColumn
+                        dataField='agencyId'
+                        isKey
+                        dataSort
+                        data
+                        filter={{
+                            type: 'RegexFilter',
+                            placeholder: 'Indtast biblioteksnummer'
+                        }}
+                        dataAlign='right'>Bibliotek
+                    </TableHeaderColumn>
+                    <TableHeaderColumn dataField='originalCount'
+                                       dataSort
+                                       dataAlign='right'
+                                       dataFormat={integerFormatter}>Originalposter</TableHeaderColumn>
+                    <TableHeaderColumn dataField='enrichmentCount'
+                                       dataSort
+                                       dataAlign='right'
+                                       dataFormat={integerFormatter}>Påhængsposter</TableHeaderColumn>
+                    <TableHeaderColumn dataField='deletedCount'
+                                       dataSort
+                                       dataAlign='right'
+                                       dataFormat={integerFormatter}>Sletteposter</TableHeaderColumn>
+                    <TableHeaderColumn dataField='ajourDate'
+                                       dataSort
+                                       dataAlign='right'>Ajourdato</TableHeaderColumn>
                 </BootstrapTable>
             </div>
         );


### PR DESCRIPTION
- Added filtering on agencyid as requested
- The count columns now have thousand separators which makes reading the
table a lot easier
- The ajour date now takes timezone into account, so the time is not
always one or two hours behind (depending on summer/wintertime)