### PR TITLE
Add date to log lines

### DIFF
--- a/hydra-api/src/main/resources/logback.xml
+++ b/hydra-api/src/main/resources/logback.xml
@@ -4,7 +4,7 @@
         <!-- encoders are assigned the type
              ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%date %level [%thread] %logger{35} - %msg%n</pattern>
         </encoder>
     </appender>
 


### PR DESCRIPTION
Date was missing from the log which was a problem when reading log for
multiple days. Solved by using same log pattern as updateservice.