### PR TITLE
Remove useless logging

### DIFF
--- a/hydra-api/src/main/java/dk/dbc/hydra/HydraAPI.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/HydraAPI.java
@@ -6,7 +6,6 @@
 package dk.dbc.hydra;
 
 import dk.dbc.hydra.common.ApplicationConstants;
-import dk.dbc.hydra.timer.Stopwatch;
 import dk.dbc.hydra.timer.StopwatchInterceptor;
 import org.slf4j.ext.XLogger;
 import org.slf4j.ext.XLoggerFactory;
@@ -27,7 +26,6 @@ import javax.ws.rs.core.Response;
 public class HydraAPI {
     private static final XLogger LOGGER = XLoggerFactory.getXLogger(HydraAPI.class);
 
-    @Stopwatch
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     @Path(ApplicationConstants.API_HYDRA_STATUS)
@@ -35,11 +33,11 @@ public class HydraAPI {
         return Response.ok(MediaType.APPLICATION_JSON).build();
     }
 
-    @Stopwatch
     @GET
     @Produces({MediaType.APPLICATION_JSON})
     @Path(ApplicationConstants.API_HYDRA_INSTANCE_NAME)
     public Response getInstanceName() {
+        LOGGER.entry();
         String res = "";
         try {
             JsonObjectBuilder jsonObject = Json.createObjectBuilder();

--- a/hydra-api/src/main/java/dk/dbc/hydra/dao/HoldingsItemsConnector.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/dao/HoldingsItemsConnector.java
@@ -37,7 +37,7 @@ public class HoldingsItemsConnector {
 
     @PostConstruct
     public void postConstruct() {
-        LOGGER.debug("HoldingsItemsConnector.postConstruct()");
+        LOGGER.entry();
 
         if (!healthCheck()) {
             throw new RuntimeException("Unable to connection to Holdings Items"); // Can't throw checked exceptions from postConstruct

--- a/hydra-api/src/main/java/dk/dbc/hydra/dao/RawRepoConnector.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/dao/RawRepoConnector.java
@@ -52,7 +52,7 @@ public class RawRepoConnector {
 
     @PostConstruct
     public void postConstruct() {
-        LOGGER.debug("RawRepoConnector.postConstruct()");
+        LOGGER.entry();
 
         if (!healthCheck()) {
             throw new RuntimeException("Unable to connect to RawRepo"); // Can't throw checked exceptions from postConstruct


### PR DESCRIPTION
Some debug logging should be trace instead, and there is no need for the
same 'time[0]' log for every getStatus call.