### PR TITLE
Allow more catalogingTemplateSets for queue types

### DIFF
--- a/hydra-api/src/main/java/dk/dbc/hydra/QueueAPI.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/QueueAPI.java
@@ -61,7 +61,7 @@ public class QueueAPI {
 
     private static final String MESSAGE_FAIL_NO_RECORDS = "Der blev ikke fundet nogen poster, så intet kan lægges på kø";
     private static final String MESSAGE_FAIL_INVALID_AGENCY_FORMAT = "Værdien '%s' har ikke et gyldigt format for et biblioteksnummer";
-    private static final String MESSAGE_FAIL_INVAILD_AGENCY_ID = "Biblioteksnummeret '%s' tilhører ikke biblioteksgruppen %s";
+    private static final String MESSAGE_FAIL_INVAILD_AGENCY_ID = "Biblioteksnummeret '%s' tilhører ikke en af biblioteksgrupperne %s";
     private static final String MESSAGE_FAIL_QUEUETYPE_NULL = "Der skal angives en køtype";
     private static final String MESSAGE_FAIL_QUEUETYPE = "Køtypen '%s' kunne ikke valideres";
     private static final String MESSAGE_FAIL_PROVIDER_NULL = "Der skal angives en provider";
@@ -324,7 +324,11 @@ public class QueueAPI {
                 agencyString = agencyString.replace(",,", ",");
             }
             final List<String> agencies = Arrays.asList(agencyString.split(","));
-            final Set<String> allowedAgencies = openAgency.getLibrariesByCatalogingTemplateSet(queueType.getCatalogingTemplateSet());
+
+            final Set<String> allowedAgencies = new HashSet<>();
+            for (String catalogingTemplateSet : queueType.getCatalogingTemplateSets()) {
+                allowedAgencies.addAll(openAgency.getLibrariesByCatalogingTemplateSet(catalogingTemplateSet));
+            }
 
             agencies.forEach(s -> s = s.trim());
 
@@ -341,7 +345,7 @@ public class QueueAPI {
                     throw new QueueException(String.format(MESSAGE_FAIL_INVALID_AGENCY_FORMAT, agency));
                 }
                 if (!allowedAgencies.contains(agency)) {
-                    throw new QueueException(String.format(MESSAGE_FAIL_INVAILD_AGENCY_ID, agency, queueType.getCatalogingTemplateSet()));
+                    throw new QueueException(String.format(MESSAGE_FAIL_INVAILD_AGENCY_ID, agency, queueType.getCatalogingTemplateSets()));
                 }
                 agencyList.add(Integer.parseInt(agency));
             }

--- a/hydra-api/src/main/java/dk/dbc/hydra/queue/QueueType.java
+++ b/hydra-api/src/main/java/dk/dbc/hydra/queue/QueueType.java
@@ -5,11 +5,14 @@
 
 package dk.dbc.hydra.queue;
 
+import java.util.Arrays;
+import java.util.List;
+
 public class QueueType {
 
     private String key;
     private String description;
-    private String catalogingTemplateSet;
+    private List<String> catalogingTemplateSets;
     private boolean changed;
     private boolean leaf;
 
@@ -37,7 +40,7 @@ public class QueueType {
     */
     public static QueueType ffu() {
         QueueType queueType = new QueueType(FFU, "FFU - RR Lokalposter");
-        queueType.catalogingTemplateSet = "ffu";
+        queueType.catalogingTemplateSets = Arrays.asList("ffu", "lokbib");
         queueType.changed = true;
         queueType.leaf = true;
 
@@ -46,8 +49,7 @@ public class QueueType {
 
     public static QueueType fbsRawrepo() {
         QueueType queueType =  new QueueType(FBS_LOCAL, "FBS - RR lokalposter + RR påhængsposter");
-
-        queueType.catalogingTemplateSet = "fbs";
+        queueType.catalogingTemplateSets = Arrays.asList("fbs", "fbslokal", "ph");
         queueType.changed = true;
         queueType.leaf = true;
 
@@ -56,8 +58,7 @@ public class QueueType {
 
     public static QueueType fbsRawrepoEnrichment() {
         QueueType queueType =  new QueueType(FBS_ENRICHMENT, "FBS - RR Påhængsposter");
-
-        queueType.catalogingTemplateSet = "fbs";
+        queueType.catalogingTemplateSets = Arrays.asList("fbs", "fbslokal", "ph");
         queueType.changed = true;
         queueType.leaf = true;
 
@@ -66,8 +67,7 @@ public class QueueType {
 
     public static QueueType fbsHoldings() {
         QueueType queueType =  new QueueType(FBS_HOLDINGS, "FBS - Beholdning");
-
-        queueType.catalogingTemplateSet = "fbs";
+        queueType.catalogingTemplateSets = Arrays.asList("fbs", "fbslokal", "ph");
         queueType.changed = true;
         queueType.leaf = true;
 
@@ -76,8 +76,7 @@ public class QueueType {
 
     public static QueueType fbsEverything() {
         QueueType queueType =  new QueueType(FBS_EVERYTHING, "FBS - Beholdning + RR lokalposter + RR påhængsposter");
-
-        queueType.catalogingTemplateSet = "fbs";
+        queueType.catalogingTemplateSets = Arrays.asList("fbs", "fbslokal", "ph");
         queueType.changed = true;
         queueType.leaf = true;
 
@@ -86,8 +85,7 @@ public class QueueType {
 
     public static QueueType dbcCommon() {
         QueueType queueType =  new QueueType(DBC_COMMON_ONLY, "DBC - Fællesposter til RR solr (uden FBS påhæng)");
-
-        queueType.catalogingTemplateSet = "dbc";
+        queueType.catalogingTemplateSets = Arrays.asList("dbc");
         queueType.changed = true;
         queueType.leaf = false;
 
@@ -121,8 +119,8 @@ public class QueueType {
         return description;
     }
 
-    public String getCatalogingTemplateSet() {
-        return catalogingTemplateSet;
+    public List<String> getCatalogingTemplateSets() {
+        return catalogingTemplateSets;
     }
 
     public boolean isChanged() {

--- a/hydra-api/src/test/java/dk/dbc/hydra/QueueAPITest.java
+++ b/hydra-api/src/test/java/dk/dbc/hydra/QueueAPITest.java
@@ -280,7 +280,7 @@ public class QueueAPITest {
                 QueueValidateResponse.class);
 
         assertThat("Not validated", queueValidateResponse.isValidated(), is(false));
-        assertThat("Invalid agency - first element", queueValidateResponse.getMessage(), is("Biblioteksnummeret '123456' tilhører ikke biblioteksgruppen ffu"));
+        assertThat("Invalid agency - first element", queueValidateResponse.getMessage(), is("Biblioteksnummeret '123456' tilhører ikke en af biblioteksgrupperne [ffu, lokbib]"));
     }
 
     @Test
@@ -305,7 +305,7 @@ public class QueueAPITest {
                 QueueValidateResponse.class);
 
         assertThat("Not validated", queueValidateResponse.isValidated(), is(false));
-        assertThat("Invalid agency - second element", queueValidateResponse.getMessage(), is("Biblioteksnummeret '654321' tilhører ikke biblioteksgruppen ffu"));
+        assertThat("Invalid agency - second element", queueValidateResponse.getMessage(), is("Biblioteksnummeret '654321' tilhører ikke en af biblioteksgrupperne [ffu, lokbib]"));
     }
 
     @Test
@@ -471,8 +471,8 @@ public class QueueAPITest {
         validateRequest.setAgencyText("111111\n");
         validateRequest.setIncludeDeleted(false);
 
-        final Set<String> agenciesStringSet = new HashSet<>();
-        agenciesStringSet.add("111111");
+        final Set<String> agenciesStringSets = new HashSet<>();
+        agenciesStringSets.add("111111");
 
         final Set<Integer> agenciesIntegerSet = new HashSet<>();
         agenciesIntegerSet.add(111111);
@@ -482,7 +482,7 @@ public class QueueAPITest {
 
         when(bean.rawrepo.getProviders()).thenReturn(Arrays.asList(new QueueProvider("the-real-provider")));
         when(bean.rawrepo.getRecordsForAgencies(agenciesIntegerSet, false)).thenReturn(recordIdSet);
-        when(bean.openAgency.getLibrariesByCatalogingTemplateSet("ffu")).thenReturn(agenciesStringSet);
+        when(bean.openAgency.getLibrariesByCatalogingTemplateSet("ffu")).thenReturn(agenciesStringSets);
         final Response validateResponse = bean.validate(jsonbContext.marshall(validateRequest));
 
         assertThat("Response code 200 - validate", validateResponse.getStatus(), is(200));


### PR DESCRIPTION
Implementation of story MS-1579. Queue validation was too strict about
which catalogingTemplateSets could be used for the queue types.